### PR TITLE
fix warnings in testperf.c

### DIFF
--- a/testperf.c
+++ b/testperf.c
@@ -54,7 +54,6 @@ static void getkeys(key      **keys,       /* list of all keys */
   *nkeys = (uint32_t)0;
   while (fgets(mytext, MAXKEYLEN, stdin))
   {
-    uint32_t i;
     mykey = (key *)renew(keyroot);
     mykey->kname = (uint8_t *)mytext;
     mytext = (char *)renew(textroot);
@@ -105,23 +104,23 @@ void driver(hashform *form)
       {
 	hash = (mykey->kname[i] ^ hash) + ((hash<<26)+(hash>>6));
       }
-      hash = mph_test_s((char*)hash, mykey->klen);
+      hash = mph_test_s((char*)(ptrdiff_t)hash, mykey->klen);
       break;
     case HEX_HM:
       sscanf((char*)mykey->kname, "%" SCNx32 " ", &hash);
-      hash = mph_test((char*)hash);
+      hash = mph_test((char*)(ptrdiff_t)hash);
       break;
     case DECIMAL_HM:
       sscanf((char*)mykey->kname, "%" SCNd32 " ", &hash);
-      hash = mph_test((char*)hash);
+      hash = mph_test((char*)(ptrdiff_t)hash);
       break;
     case AB_HM:
       sscanf((char*)mykey->kname, "%" SCNx32 " %" SCNx32 " ", &a, &b);
-      hash = mph_test_s((char*)a,b);
+      hash = mph_test_s((char*)(ptrdiff_t)a,b);
       break;
     case ABDEC_HM:
       sscanf((char*)mykey->kname, "%" SCNd32 " %" SCNd32 " ", &a, &b);
-      hash = mph_test_s((char*)a,b);
+      hash = mph_test_s((char*)(ptrdiff_t)a,b);
       break;
     }
     printf("%8d  %.*s\n", hash, mykey->klen, mykey->kname);


### PR DESCRIPTION
the testperf.c has several warnings on my 64bit Mac machine:
```
cc -O   -c -o testperf.o testperf.c
testperf.c:108:25: warning: cast to 'char *' from smaller integer type 'uint32_t' (aka 'unsigned int') [-Wint-to-pointer-cast]
      hash = mph_test_s((char*)hash, mykey->klen);
                        ^
testperf.c:112:23: warning: cast to 'char *' from smaller integer type 'uint32_t' (aka 'unsigned int') [-Wint-to-pointer-cast]
      hash = mph_test((char*)hash);
                      ^
testperf.c:112:23: warning: cast to 'char *' from smaller integer type 'uint32_t' (aka 'unsigned int') [-Wint-to-pointer-cast]
testperf.c:116:23: warning: cast to 'char *' from smaller integer type 'uint32_t' (aka 'unsigned int') [-Wint-to-pointer-cast]
      hash = mph_test((char*)hash);
                      ^
testperf.c:116:23: warning: cast to 'char *' from smaller integer type 'uint32_t' (aka 'unsigned int') [-Wint-to-pointer-cast]
testperf.c:120:25: warning: cast to 'char *' from smaller integer type 'uint32_t' (aka 'unsigned int') [-Wint-to-pointer-cast]
      hash = mph_test_s((char*)a,b);
                        ^
testperf.c:124:25: warning: cast to 'char *' from smaller integer type 'uint32_t' (aka 'unsigned int') [-Wint-to-pointer-cast]
      hash = mph_test_s((char*)a,b);
                        ^
7 warnings generated.
```

this pr fixed these warnings.